### PR TITLE
✨ Add country-based purchase flow for Korean users

### DIFF
--- a/components/homepage/PixelGrid.tsx
+++ b/components/homepage/PixelGrid.tsx
@@ -7,17 +7,30 @@ import { supabase } from "@/lib/supabaseClient";
 import { PurchasedPixelModal } from "@/components/pixels/PurchasedPixelModal";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { CountrySelectModal } from "@/components/purchase/CountrySelectModal";
-import type { PixelData } from "@/types/pixel";
+import { PixelPurchaseModal } from "@/components/purchase/PixelPurchaseModal";
 
 const GRID_SIZE = 1000;
 const PIXEL_SIZE = 10;
+
+interface PixelData {
+  id: string;
+  x: number;
+  y: number;
+  name: string;
+  message: string;
+  image_url: string;
+  created_at: string;
+  width?: number;
+  height?: number;
+}
 
 export function PixelGrid() {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const [purchasedPixels, setPurchasedPixels] = useState<PixelData[]>([]);
   const [selectedPixel, setSelectedPixel] = useState<{ x: number; y: number } | null>(null);
-  const [isCountryModalOpen, setIsCountryModalOpen] = useState(false);
+  const [showPurchaseModal, setShowPurchaseModal] = useState(false);
+  const [showCountryModal, setShowCountryModal] = useState(false);
 
   const [selectedPurchasedPixel, setSelectedPurchasedPixel] = useState<PixelData | null>(null);
   const [isPurchasedModalOpen, setIsPurchasedModalOpen] = useState(false);
@@ -41,7 +54,7 @@ export function PixelGrid() {
     if (isCovered) return;
 
     setSelectedPixel({ x, y });
-    setIsCountryModalOpen(true);
+    setShowCountryModal(true);
   };
 
   const handlePurchasedPixelClick = (pixel: PixelData) => {
@@ -53,14 +66,23 @@ export function PixelGrid() {
     setPurchasedPixels((prev) => [...prev, ...newPixels]);
   };
 
-  const handleCloseCountryModal = () => {
+  const handleClosePurchaseModal = () => {
     setSelectedPixel(null);
-    setIsCountryModalOpen(false);
+    setShowPurchaseModal(false);
+  };
+
+  const handleCloseCountryModal = () => {
+    setShowCountryModal(false);
   };
 
   const handleClosePurchasedModal = () => {
     setSelectedPurchasedPixel(null);
     setIsPurchasedModalOpen(false);
+  };
+
+  const handleConfirmNonKorean = () => {
+    setShowCountryModal(false);
+    setShowPurchaseModal(true);
   };
 
   const rowVirtualizer = useVirtualizer({
@@ -147,16 +169,27 @@ export function PixelGrid() {
         </div>
       </div>
 
-      {/* 🌏 국가 선택 모달 → 내부에서 구매 or 한국 안내 분기 */}
+      {/* 🌏 국가 선택 모달 */}
       <CountrySelectModal
-        open={isCountryModalOpen}
+        open={showCountryModal}
         onClose={handleCloseCountryModal}
         selectedPixel={selectedPixel}
-        onPurchaseSuccess={handlePixelPurchase}
+        onProceed={handleConfirmNonKorean}
+        onPurchaseSuccess={handlePixelPurchase} // 🔥 이거 추가
       />
 
+      {/* 💸 구매 모달 */}
+      {selectedPixel && showPurchaseModal && (
+        <PixelPurchaseModal
+          open={true}
+          onClose={handleClosePurchaseModal}
+          selectedPixel={selectedPixel}
+          onPurchaseSuccess={handlePixelPurchase}
+        />
+      )}
+
       {/* 🚨 신고 모달 */}
-      {selectedPurchasedPixel && !isCountryModalOpen && (
+      {selectedPurchasedPixel && (
         <PurchasedPixelModal
           open={isPurchasedModalOpen}
           onClose={handleClosePurchasedModal}

--- a/components/purchase/CountrySelectModal.tsx
+++ b/components/purchase/CountrySelectModal.tsx
@@ -2,69 +2,82 @@
 "use client";
 
 import { useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { KoreanPurchaseInfoModal } from "./KoreanPurchaseInfoModal";
 import { PixelPurchaseModal } from "@/components/purchase/PixelPurchaseModal";
-import type { PixelData } from "@/types/pixel";
 
 interface CountrySelectModalProps {
-    open: boolean;
-    onClose: () => void;
-    selectedPixel: { x: number; y: number } | null;
-    onPurchaseSuccess: (pixels: PixelData[]) => void;
+  open: boolean;
+  onClose: () => void;
+  selectedPixel: { x: number; y: number } | null;
+  onPurchaseSuccess: (pixels: any[]) => void;
+  onProceed: () => void; // ✅ 새로 추가된 prop
 }
 
-export function CountrySelectModal({ open, onClose, selectedPixel, onPurchaseSuccess }: CountrySelectModalProps) {
-    const [koreanModalOpen, setKoreanModalOpen] = useState(false);
-    const [purchaseModalOpen, setPurchaseModalOpen] = useState(false);
+export function CountrySelectModal({
+  open,
+  onClose,
+  selectedPixel,
+  onPurchaseSuccess,
+  onProceed,
+}: CountrySelectModalProps) {
+  const [koreanModalOpen, setKoreanModalOpen] = useState(false);
+  const [purchaseModalOpen, setPurchaseModalOpen] = useState(false);
 
-    const handleYes = () => {
-        setKoreanModalOpen(true);
-        onClose();
-    };
+  const handleYes = () => {
+    setKoreanModalOpen(true);
+    onClose();
+  };
 
-    const handleNo = () => {
-        setPurchaseModalOpen(true);
-        onClose();
-    };
+  const handleNo = () => {
+    setPurchaseModalOpen(true);
+    onClose();
+    onProceed();
+  };
 
-    return (
-        <>
-            <Dialog open={open} onOpenChange={onClose}>
-                <DialogContent className="sm:max-w-md">
-                    <DialogHeader>
-                        <DialogTitle>Are you accessing from Korea?</DialogTitle>
-                        <DialogDescription>
-                            This helps us guide you to the appropriate pixel purchase method.
-                            Due to local PayPal restrictions, Korean users must proceed differently.
-                        </DialogDescription>
-                    </DialogHeader>
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onClose}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Are you accessing from Korea?</DialogTitle>
+            <DialogDescription>
+              This helps us guide you to the appropriate pixel purchase method.
+              Due to local PayPal restrictions, Korean users must proceed
+              differently.
+            </DialogDescription>
+          </DialogHeader>
 
-                    <DialogFooter className="flex justify-end gap-2 pt-4">
-                        <Button variant="outline" onClick={handleYes}>
-                            🇰🇷 Yes, I&apos;m in Korea
-                        </Button>
-                        <Button onClick={handleNo}>
-                            🌐 No, I&apos;m not in Korea
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
+          <DialogFooter className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={handleYes}>
+              🇰🇷 Yes, I&apos;m in Korea
+            </Button>
+            <Button onClick={handleNo}>🌐 No, I&apos;m not in Korea</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-            {/* 🇰🇷 한국 사용자 안내 모달 */}
-            <KoreanPurchaseInfoModal
-                open={koreanModalOpen}
-                onClose={() => setKoreanModalOpen(false)}
-            />
+      {/* 🇰🇷 한국 사용자 안내 모달 */}
+      <KoreanPurchaseInfoModal
+        open={koreanModalOpen}
+        onClose={() => setKoreanModalOpen(false)}
+      />
 
-            {/* 💳 일반 구매 모달 */}
-            <PixelPurchaseModal
-                open={purchaseModalOpen}
-                onClose={() => setPurchaseModalOpen(false)}
-                selectedPixel={selectedPixel}
-                onPurchaseSuccess={onPurchaseSuccess}
-            />
-        </>
-    );
+      {/* 💳 일반 구매 모달 */}
+      <PixelPurchaseModal
+        open={purchaseModalOpen}
+        onClose={() => setPurchaseModalOpen(false)}
+        selectedPixel={selectedPixel}
+        onPurchaseSuccess={onPurchaseSuccess}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
- Added CountrySelectModal to prompt users if they're accessing from Korea
- Integrated KoreanPurchaseInfoModal for Korean-specific purchase instructions
- Updated PixelGrid.tsx to open CountrySelectModal before showing the actual purchase modal
- Refactored PixelGrid modal state management to support conditional rendering
- Ensured onProceed and onPurchaseSuccess props are correctly wired to avoid build errors